### PR TITLE
Webgrindへのリンクのport番号がパスになっていたのを修正

### DIFF
--- a/app/src/index.php
+++ b/app/src/index.php
@@ -7,7 +7,8 @@
 <h1>『WEB+DB PRESS Vol.121』「PHPのパフォーマンスチューニングをしよう」ソースコード</h1>
 <?php
 $profile_port = getenv('PROFILE_PORT');
-echo "<a href=\"$profile_port\" target=\"_blank\">プロファイリングツール「Webgrind」を見る</a>";
+$hostname = $_SERVER['HTTP_HOST'];
+echo "<a href=\"http://$hostname:$profile_port\" target=\"_blank\">プロファイリングツール「Webgrind」を見る</a>";
 ?>
 <ul>
     <?php


### PR DESCRIPTION
Webgrindへのリンクが `http://localhost/10080` になっていたのを `http://localhost:10080` になるように修正してみました。

また、モダンブラウザでは10080番ポートをブロックするようになったので、READMEなどで補足いただけるとこれから試す方が迷わなかと思いました。